### PR TITLE
Fix string literal issue in gmail_refresh

### DIFF
--- a/src/gmail_refresh.py
+++ b/src/gmail_refresh.py
@@ -16,8 +16,7 @@ import config
 WF = Workflow()
 HP = HTMLParser()
 EMAIL_LIST = dict((x, []) for x in config.SYSTEM_LABELS.keys())
-FIELDS = """'messages/id,messages/threadId,messages/labelIds,messages/snippet,\
-messages/payload/headers'"""
+FIELDS = 'messages/id,messages/threadId,messages/labelIds,messages/snippet,messages/payload/headers'
 
 
 class PseudoStorage():


### PR DESCRIPTION
Seems like that there's an issue with the `FIELDS` string literal. I'm getting _"No mails found!"_ message no matter what. With this fix, it's back to normal. 

To test the functionality, please make sure you restart Alfred and delete the Gmail workflow cache file at `~/Library/Caches/com.runningwithcrayons.Alfred-3/Workflow Data/com.fniephaus.gmail/gmail_inbox.cpickle`.